### PR TITLE
Introduce custom name for ECS Task Execution Role

### DIFF
--- a/dataops-infra/infra/stacks/airflow_cluster_stack.py
+++ b/dataops-infra/infra/stacks/airflow_cluster_stack.py
@@ -19,8 +19,8 @@ class AirflowClusterStack(core.Stack):
         # Fargate task execution role
         self.task_execution_role = iam.Role(
             self,
-            "ecsTaskExecutionRole",
-            role_name="ecsTaskExecutionRole",
+            "AirlfowTaskExecutionRole",
+            role_name="AirlfowTaskExecutionRole",
             assumed_by=iam.ServicePrincipal("ecs-tasks.amazonaws.com"),
             managed_policies=[
                 iam.ManagedPolicy.from_aws_managed_policy_name(


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-samples/dataops-platform-airflow-dbt/issues/1

*Description of changes:*
This PR introduces a custom name for ECS Task Execution Role. This avoids _"ecsTaskExecutionRole already exists"_ error when deploying `AirflowClusterStack`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
