### PR TITLE
Restrict iam:PassRole policy for AirflowTaskRole

### DIFF
--- a/dataops-infra/infra/stacks/airflow_cluster_stack.py
+++ b/dataops-infra/infra/stacks/airflow_cluster_stack.py
@@ -60,7 +60,7 @@ class AirflowClusterStack(core.Stack):
                 iam.PolicyStatement(
                     effect=iam.Effect.ALLOW,
                     actions=["iam:PassRole"],
-                    resources=["*"],
+                    resources=[self.task_execution_role.role_arn, self.airflow_task_role.role_arn],
                     conditions={
                         "StringLike": {"iam:PassedToService": "ecs-tasks.amazonaws.com"}
                     },


### PR DESCRIPTION
*Description of changes:*
This PR removes a wildcard from the IAM Policy `AirflowECSOperatorPolicy` related to the `iam:PassRole` action. Now the IAM Roles that needs to be passed to the _dbt_ Fargate Task when the Airflow DAG is executed are explicitly declared.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
